### PR TITLE
Fix bug while producing HTTP Response metrics

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   linter-check:
     name: Linter Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   test:
     name: Running Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+## 1.1.1 - 2025-01-31
+
+### Fixed
+
+- Fixed a bug where the metrics were not being sent with the proper status code response label.
+- Refactor the way the metrics are being produced.
+
 ## 1.1.0 - 2025-01-07
 
 ### Changed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/http-client-component "1.1.0"
+(defproject net.clojars.macielti/http-client-component "1.1.1"
 
   :description "HTTP Client Component"
 


### PR DESCRIPTION
### Fixed

- Fixed a bug where the metrics were not being sent with the proper status code response label.
- Refactor the way the metrics are being produced.