### PR TITLE
Release 4.0.0 — rename project to http-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 4.0.0 - 2026-04-04
+
+### Changed
+
+- Renamed project from `http-client-component` to `http-client`.
+- Added `HttpClientComponent` and `RequestMap` schemas to `http-client.with-httpkit-client`.
+- Bumped `cheshire` to `6.2.0`, `medley` to `1.10.0`, and `lein-clojure-lsp` to `2.0.14`.
+
 ## 3.2.3 - 2026-02-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Clojars Project](https://img.shields.io/clojars/v/net.clojars.macielti/http-client-component.svg)](https://clojars.org/net.clojars.macielti/http-client-component)
+[![Clojars Project](https://img.shields.io/clojars/v/net.clojars.macielti/http-client.svg)](https://clojars.org/net.clojars.macielti/http-client)
 ![Compatible with GraalVM](https://img.shields.io/badge/compatible_with-GraalVM-green)
 
 # HTTP Client Component

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/http-client-component "3.2.3"
+(defproject net.clojars.macielti/http-client "4.0.0"
 
   :description "HTTP Client Component"
 
@@ -14,14 +14,14 @@
                  [prismatic/schema "1.4.1"]
                  [clj-commons/iapetos "0.1.14"]
                  [org.clojure/tools.logging "1.3.1"]
-                 [dev.weavejester/medley "1.9.0"]
+                 [dev.weavejester/medley "1.10.0"]
                  [hato "1.0.0"]
-                 [cheshire "6.1.0"]]
+                 [cheshire "6.2.0"]]
 
   :profiles {:dev {:test-paths   ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :plugins      [[lein-cloverage "1.2.4"]
-                                  [com.github.clojure-lsp/lein-clojure-lsp "2.0.13"]
+                                  [com.github.clojure-lsp/lein-clojure-lsp "2.0.14"]
                                   [com.github.liquidz/antq "RELEASE"]]
 
                    :dependencies [[nubank/matcher-combinators "3.10.0"]

--- a/src/http_client/models/targets.clj
+++ b/src/http_client/models/targets.clj
@@ -1,4 +1,4 @@
-(ns http-client-component.models.targets
+(ns http-client.models.targets
   (:require [schema.core :as s]))
 
 (def targets

--- a/src/http_client/with_hato.clj
+++ b/src/http_client/with_hato.clj
@@ -1,20 +1,20 @@
-(ns http-client-component.with-httpkit-client
+(ns http-client.with-hato
   (:require [camel-snake-kebab.core :as camel-snake-kebab]
-            [cheshire.core :as json]
             [clojure.tools.logging :as log]
-            [http-client-component.models.targets :as models.targets]
+            [hato.client :as hc]
+            [http-client.models.targets :as models.targets]
             [iapetos.core :as prometheus]
             [integrant.core :as ig]
             [medley.core :as medley]
-            [org.httpkit.client :as hk-client]
             [schema.core :as s]))
 
 (def method->request-fn
-  {:post   ^:clj-kondo/ignore hk-client/post
-   :get    ^:clj-kondo/ignore hk-client/get
-   :put    ^:clj-kondo/ignore hk-client/put
-   :patch  ^:clj-kondo/ignore hk-client/patch
-   :delete ^:clj-kondo/ignore hk-client/delete})
+  {:post   hc/post
+   :get    hc/get
+   :put    hc/put
+   :patch  hc/patch
+   :head   hc/head
+   :delete hc/delete})
 
 (defmulti request!
   (fn [_ {:keys [current-env]}]
@@ -59,19 +59,15 @@
     (swap! requests conj request-map)
     (request-fn uri payload)))
 
-(defn requests
-  [{:keys [requests]}]
-  (map (fn [request]
-         (medley/update-existing-in request [:payload :body] #(json/decode % true))) @requests))
-
 (defmethod ig/init-key ::http-client
   [_ {:keys [components]}]
   (log/info :starting ::http-client)
-  (medley/assoc-some {:requests    (atom [])
-                      :service     (-> components :config :service-name)
-                      :current-env (-> components :config :current-env)}
-                     :targets (some->> components :config :targets (s/validate models.targets/Targets))
-                     :prometheus-registry (-> components :prometheus :registry)))
+  (let [targets (-> components :config :targets)]
+    (medley/assoc-some {:requests    (atom [])
+                        :service     (-> components :config :service-name)
+                        :current-env (-> components :config :current-env)
+                        :targets     (s/validate models.targets/Targets targets)}
+                       :prometheus-registry (-> components :prometheus :registry))))
 
 (defmethod ig/halt-key! ::http-client
   [_ _]

--- a/src/http_client/with_httpkit_client.clj
+++ b/src/http_client/with_httpkit_client.clj
@@ -1,20 +1,35 @@
-(ns http-client-component.with-hato
+(ns http-client.with-httpkit-client
   (:require [camel-snake-kebab.core :as camel-snake-kebab]
+            [cheshire.core :as json]
             [clojure.tools.logging :as log]
-            [hato.client :as hc]
-            [http-client-component.models.targets :as models.targets]
+            [http-client.models.targets :as models.targets]
             [iapetos.core :as prometheus]
             [integrant.core :as ig]
             [medley.core :as medley]
-            [schema.core :as s]))
+            [org.httpkit.client :as hk-client]
+            [schema.core :as s])
+  (:import (iapetos.registry IapetosRegistry)))
 
 (def method->request-fn
-  {:post   hc/post
-   :get    hc/get
-   :put    hc/put
-   :patch  hc/patch
-   :head   hc/head
-   :delete hc/delete})
+  {:post   ^:clj-kondo/ignore hk-client/post
+   :get    ^:clj-kondo/ignore hk-client/get
+   :put    ^:clj-kondo/ignore hk-client/put
+   :patch  ^:clj-kondo/ignore hk-client/patch
+   :delete ^:clj-kondo/ignore hk-client/delete})
+
+(s/defschema RequestMap
+  {:method                       (s/enum :get :post :put :patch :delete)
+   :endpoint                     s/Str
+   :target                       s/Keyword
+   :payload                      {s/Any s/Any}
+   (s/optional-key :endpoint-id) s/Str})
+
+(s/defschema HttpClientComponent
+  {:requests                             (s/atom [RequestMap])
+   :service                              s/Str
+   :current-env                          (s/enum :test :prod)
+   (s/optional-key :targets)             models.targets/Targets
+   (s/optional-key :prometheus-registry) IapetosRegistry})
 
 (defmulti request!
   (fn [_ {:keys [current-env]}]
@@ -41,7 +56,7 @@
 
 (s/defmethod request! :prod
   [{:keys [method endpoint target payload endpoint-id] :as _request-map}
-   {:keys [prometheus-registry service targets] :as _http-client}]
+   {:keys [prometheus-registry service targets] :as _http-client} :- HttpClientComponent]
   (let [request-fn (method->request-fn method)
         uri (-> (get targets target) (str endpoint))
         async-callback-fn (fn [{:keys [opts] :as response}]
@@ -53,21 +68,25 @@
 
 (s/defmethod request! :test
   [{:keys [method endpoint target payload] :as request-map}
-   {:keys [requests targets] :as _http-client}]
+   {:keys [requests targets] :as _http-client} :- HttpClientComponent]
   (let [uri (-> (get targets target) (str endpoint))
         request-fn (method->request-fn method)]
     (swap! requests conj request-map)
     (request-fn uri payload)))
 
+(defn requests
+  [{:keys [requests]}]
+  (map (fn [request]
+         (medley/update-existing-in request [:payload :body] #(json/decode % true))) @requests))
+
 (defmethod ig/init-key ::http-client
   [_ {:keys [components]}]
   (log/info :starting ::http-client)
-  (let [targets (-> components :config :targets)]
-    (medley/assoc-some {:requests    (atom [])
-                        :service     (-> components :config :service-name)
-                        :current-env (-> components :config :current-env)
-                        :targets     (s/validate models.targets/Targets targets)}
-                       :prometheus-registry (-> components :prometheus :registry))))
+  (medley/assoc-some {:requests    (atom [])
+                      :service     (-> components :config :service-name)
+                      :current-env (-> components :config :current-env)}
+                     :targets (some->> components :config :targets (s/validate models.targets/Targets))
+                     :prometheus-registry (-> components :prometheus :registry)))
 
 (defmethod ig/halt-key! ::http-client
   [_ _]

--- a/test/integration/with_hato_test.clj
+++ b/test/integration/with_hato_test.clj
@@ -1,7 +1,7 @@
 (ns with-hato-test
   (:require [cheshire.core :as json]
             [clojure.test :refer [is testing]]
-            [http-client-component.with-hato :as component.http-client-with-hato]
+            [http-client.with-hato :as component.http-client-with-hato]
             [integrant.core :as ig]
             [matcher-combinators.test :refer [match?]]
             [schema.test :as s]))


### PR DESCRIPTION
## Summary

- Renamed project from `http-client-component` to `http-client` (namespace moved from `http-client-component.*` to `http-client.*`)
- Added `HttpClientComponent` and `RequestMap` schemas to `http-client.with-httpkit-client`
- Bumped `cheshire` to `6.2.0`, `medley` to `1.10.0`, and `lein-clojure-lsp` to `2.0.14`

## Test plan

- [x] Integration tests pass (`with_hato_test.clj`)
- [x] All namespace references updated in src and test files
- [x] `project.clj` reflects new artifact id and version `4.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)